### PR TITLE
Fix ForeignKeys in views, make it possible to use a database alias for synchronisation

### DIFF
--- a/django_pgviews/apps.py
+++ b/django_pgviews/apps.py
@@ -15,7 +15,7 @@ class ViewConfig(apps.AppConfig):
     name = "django_pgviews"
     verbose_name = "Django Postgres Views"
 
-    def sync_pgviews(self, sender, app_config, **kwargs):
+    def sync_pgviews(self, sender, app_config, using, **kwargs):
         """Forcibly sync the views.
         """
         self.counter = self.counter + 1
@@ -28,7 +28,7 @@ class ViewConfig(apps.AppConfig):
             from .models import ViewSyncer
 
             vs = ViewSyncer()
-            vs.run(force=True, update=True)
+            vs.run(force=True, update=True, using=using)
 
     def ready(self):
         """Find and setup the apps to set the post_migrate hooks for.

--- a/django_pgviews/management/commands/clear_pgviews.py
+++ b/django_pgviews/management/commands/clear_pgviews.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.apps import apps
-from django.db import connection
+from django.db import DEFAULT_DB_ALIAS, connections
 
 from django_pgviews.view import clear_view, View, MaterializedView
 
@@ -13,9 +13,19 @@ log = logging.getLogger("django_pgviews.sync_pgviews")
 class Command(BaseCommand):
     help = """Clear Postgres views. Use this before running a migration"""
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--database",
+            default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to synchronize. Defaults to the "default" database.',
+        )
+
     def handle(self, **options):
         """
         """
+        # Get the database we're operating from
+        db = options["database"]
+        connection = connections[db]
         for view_cls in apps.get_models():
             if not (isinstance(view_cls, type) and issubclass(view_cls, View) and hasattr(view_cls, "sql")):
                 continue

--- a/django_pgviews/management/commands/sync_pgviews.py
+++ b/django_pgviews/management/commands/sync_pgviews.py
@@ -2,8 +2,7 @@ from optparse import make_option
 import logging
 
 from django.core.management.base import BaseCommand
-from django.db import connection
-from django.apps import apps
+from django.db import DEFAULT_DB_ALIAS
 
 from django_pgviews.models import ViewSyncer
 
@@ -30,7 +29,12 @@ class Command(BaseCommand):
             help="""Force replacement of pre-existing views where
             breaking changes have been made to the schema.""",
         )
+        parser.add_argument(
+            "--database",
+            default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to synchronize. Defaults to the "default" database.',
+        )
 
-    def handle(self, force, update, **options):
+    def handle(self, force, update, database, **options):
         vs = ViewSyncer()
-        vs.run(force, update)
+        vs.run(force, update, using=database)

--- a/django_pgviews/signals.py
+++ b/django_pgviews/signals.py
@@ -1,5 +1,5 @@
 from django.dispatch import Signal
 
 
-view_synced = Signal(providing_args=["update", "force", "status", "has_changed"])
+view_synced = Signal(providing_args=["update", "force", "status", "has_changed", "using"])
 all_views_synced = Signal()

--- a/django_pgviews/view.py
+++ b/django_pgviews/view.py
@@ -56,7 +56,7 @@ def realize_deferred_projections(sender, *args, **kwargs):
             # attribute or explicitly-defined field with that name.
             if hasattr(view_cls, name) or hasfield(view_cls, name):
                 continue
-            copy.copy(field).contribute_to_class(view_cls, name)
+            copy.deepcopy(field).contribute_to_class(view_cls, name)
 
 
 models.signals.class_prepared.connect(realize_deferred_projections)


### PR DESCRIPTION
Hey there!

This is a combination of https://github.com/mypebble/django-pgviews/pull/52/files and another fix that we use in production (ForeignKeys don't work properly with views unless deep copy is used on copied fields). Sorry for two things at once, but it'd just be nice to have it all upstreamed.

Paging @seroy who did both fixes.
