### PR TITLE
Support multiple databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # Virtualenvs for testing
 .venv
 venv/
+.direnv
+.envrc
 
 # Temporary testing directories
 test__*

--- a/README.md
+++ b/README.md
@@ -382,6 +382,25 @@ Provides args:
 * `sender` - Always `None`
 
 
+### Multiple databases
+
+django-pgviews can use multiple databases.  Similar to Django's `migrate`
+management command, our commands (`clear_pgviews`, `refresh_pgviews`,
+`sync_pgviews`) operate on one database at a time. You can specify which
+database to synchronize by providing the `--database` option. For example:
+
+```shell
+python manage.py sync_pgviews  # uses default db
+python manage.py sync_pgviews --database=myotherdb
+```
+
+Unless using custom routers, django-pgviews will sync all views to the specified
+database. If you want to interact with multiple databases automatically, you'll
+need to take some additional steps. Please refer to Django's [Automatic database
+routing](https://docs.djangoproject.com/en/3.2/topics/db/multi-db/#automatic-database-routing)
+to pin views to specific databases.
+
+
 ## Django Compatibility
 
 <table>

--- a/django_pgviews/apps.py
+++ b/django_pgviews/apps.py
@@ -16,7 +16,7 @@ class ViewConfig(apps.AppConfig):
     name = "django_pgviews"
     verbose_name = "Django Postgres Views"
 
-    def sync_pgviews(self, sender, app_config, **kwargs):
+    def sync_pgviews(self, sender, app_config, using, **kwargs):
         """
         Forcibly sync the views.
         """
@@ -35,6 +35,7 @@ class ViewConfig(apps.AppConfig):
                 force=True,
                 update=True,
                 materialized_views_check_sql_changed=getattr(settings, "MATERIALIZED_VIEWS_CHECK_SQL_CHANGED", False),
+                using=using,
             )
             self.counter = 0
 

--- a/django_pgviews/management/commands/refresh_pgviews.py
+++ b/django_pgviews/management/commands/refresh_pgviews.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from django.db import DEFAULT_DB_ALIAS
 
 from django_pgviews.models import ViewRefresher
 
@@ -14,6 +15,11 @@ class Command(BaseCommand):
             dest="concurrently",
             help="Refresh concurrently if the materialized view supports it",
         )
+        parser.add_argument(
+            "--database",
+            default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to synchronize. Defaults to the "default" database.',
+        )
 
-    def handle(self, concurrently, **options):
-        ViewRefresher().run(concurrently)
+    def handle(self, concurrently, database, **options):
+        ViewRefresher().run(concurrently, using=database)

--- a/django_pgviews/management/commands/sync_pgviews.py
+++ b/django_pgviews/management/commands/sync_pgviews.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import DEFAULT_DB_ALIAS
 
 from django_pgviews.models import ViewSyncer
 
@@ -46,11 +47,16 @@ class Command(BaseCommand):
                 "if the SQL is different. By default uses django setting MATERIALIZED_VIEWS_CHECK_SQL_CHANGED."
             ),
         )
+        parser.add_argument(
+            "--database",
+            default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to synchronize. Defaults to the "default" database.',
+        )
 
-    def handle(self, force, update, materialized_views_check_sql_changed, **options):
+    def handle(self, force, update, materialized_views_check_sql_changed, database, **options):
         vs = ViewSyncer()
 
         if materialized_views_check_sql_changed is None:
             materialized_views_check_sql_changed = getattr(settings, "MATERIALIZED_VIEWS_CHECK_SQL_CHANGED", False)
 
-        vs.run(force, update, materialized_views_check_sql_changed=materialized_views_check_sql_changed)
+        vs.run(force, update, using=database, materialized_views_check_sql_changed=materialized_views_check_sql_changed)

--- a/django_pgviews/signals.py
+++ b/django_pgviews/signals.py
@@ -1,5 +1,5 @@
 from django.dispatch import Signal
 
 
-view_synced = Signal(providing_args=["update", "force", "status", "has_changed"])
-all_views_synced = Signal()
+view_synced = Signal(providing_args=["update", "force", "status", "has_changed", "using"])
+all_views_synced = Signal(providing_args=["using"])

--- a/tests/test_project/test_project/multidbtest/models.py
+++ b/tests/test_project/test_project/multidbtest/models.py
@@ -1,0 +1,29 @@
+from django.db import models
+from django_pgviews import view
+
+
+class Observation(models.Model):
+    date = models.DateField()
+    temperature = models.IntegerField()
+
+
+VIEW_SQL = """
+WITH summary AS (
+    SELECT
+        date_trunc('month', date) AS date,
+        count(*)
+    FROM multidbtest_observation
+    GROUP BY 1
+    ORDER BY date
+) SELECT
+    ROW_NUMBER() OVER () AS id,
+    date,
+    count
+FROM summary;
+"""
+
+
+class MonthlyObservation(view.ReadOnlyMaterializedView):
+    sql = VIEW_SQL
+    date = models.DateField()
+    count = models.IntegerField()

--- a/tests/test_project/test_project/multidbtest/routers.py
+++ b/tests/test_project/test_project/multidbtest/routers.py
@@ -1,0 +1,37 @@
+class WeatherPinnedRouter:
+    """
+    A router to control all database operations on models and views in the
+    multidbtest application.
+    """
+
+    def db_for_read(self, model, **hints):
+        """
+        Attempts to read multidbtest models go to weather_db.
+        """
+        if model._meta.app_label == "multidbtest":
+            return "weather_db"
+        return "default"
+
+    def db_for_write(self, model, **hints):
+        """
+        Attempts to write multidbtest models go to weather_db.
+        """
+        if model._meta.app_label == "multidbtest":
+            return "weather_db"
+        return "default"
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """
+        Allow relations if a model in the multidbtest app is involved.
+        """
+        if obj1._meta.app_label == "multidbtest" or obj2._meta.app_label == "multidbtest":
+            return True
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """
+        Make sure the multidbtest models only appear in the weather_db database.
+        """
+        if app_label == "multidbtest":
+            return db == "weather_db"
+        else:
+            return db == "default"

--- a/tests/test_project/test_project/multidbtest/tests.py
+++ b/tests/test_project/test_project/multidbtest/tests.py
@@ -1,0 +1,133 @@
+import datetime as dt
+
+from django.core.management import call_command
+from django.dispatch import receiver
+from django.db import connections, DEFAULT_DB_ALIAS
+from django.test import TestCase, override_settings
+
+from django_pgviews.signals import view_synced
+
+from .models import Observation, MonthlyObservation
+from .routers import WeatherPinnedRouter
+
+from ..viewtest.models import RelatedView
+
+
+@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
+class WeatherPinnedViewConnectionTest(TestCase):
+    """Weather views should only return weather_db when pinned."""
+
+    def test_weather_view_using_weather_db(self):
+        self.assertEqual(MonthlyObservation.get_view_connection(using="weather_db"), connections["weather_db"])
+
+    def test_weather_view_using_default_db(self):
+        self.assertIsNone(MonthlyObservation.get_view_connection(using=DEFAULT_DB_ALIAS))
+
+    def test_other_app_view_using_weather_db(self):
+        self.assertIsNone(RelatedView.get_view_connection(using="weather_db"))
+
+    def test_other_app_view_using_default_db(self):
+        self.assertEqual(RelatedView.get_view_connection(using=DEFAULT_DB_ALIAS), connections["default"])
+
+
+class DefaultRouterViewConnectionTest(TestCase):
+    """All views should should use default alias by default."""
+
+    def test_weather_view_default(self):
+        self.assertEqual(MonthlyObservation.get_view_connection(using=DEFAULT_DB_ALIAS), connections["default"])
+
+    def test_other_app_view_default(self):
+        self.assertEqual(RelatedView.get_view_connection(using=DEFAULT_DB_ALIAS), connections["default"])
+
+
+@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
+class WeatherPinnedRefreshViewTest(TestCase):
+    """View.refresh() should automatically select the appropriate database."""
+
+    databases = {DEFAULT_DB_ALIAS, "weather_db"}
+
+    def test_pre_refresh(self):
+        Observation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+        Observation.objects.create(date=dt.date(2022, 1, 3), temperature=20)
+        self.assertEqual(MonthlyObservation.objects.count(), 0)
+
+    def test_refresh(self):
+        Observation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+        Observation.objects.create(date=dt.date(2022, 1, 3), temperature=20)
+        MonthlyObservation.refresh()
+        self.assertEqual(MonthlyObservation.objects.count(), 1)
+
+
+@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
+class WeatherPinnedMigrateTest(TestCase):
+    """Ensure views are only sync'd against the correct database on migrate."""
+
+    databases = {DEFAULT_DB_ALIAS, "weather_db"}
+
+    def test_default(self):
+        synced_views = []
+
+        @receiver(view_synced)
+        def on_view_synced(sender, **kwargs):
+            synced_views.append(sender)
+
+        call_command("migrate", database=DEFAULT_DB_ALIAS)
+        self.assertNotIn(MonthlyObservation, synced_views)
+        self.assertIn(RelatedView, synced_views)
+
+    def test_weather_db(self):
+        synced_views = []
+
+        @receiver(view_synced)
+        def on_view_synced(sender, **kwargs):
+            synced_views.append(sender)
+
+        call_command("migrate", database="weather_db")
+        self.assertIn(MonthlyObservation, synced_views)
+        self.assertNotIn(RelatedView, synced_views)
+
+
+@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
+class WeatherPinnedSyncPGViewsTest(TestCase):
+    """Ensure views are only sync'd against the correct database with sync_pgviews."""
+
+    databases = {DEFAULT_DB_ALIAS, "weather_db"}
+
+    def test_default(self):
+        synced_views = []
+
+        @receiver(view_synced)
+        def on_view_synced(sender, **kwargs):
+            synced_views.append(sender)
+
+        call_command("sync_pgviews", database=DEFAULT_DB_ALIAS)
+        self.assertNotIn(MonthlyObservation, synced_views)
+        self.assertIn(RelatedView, synced_views)
+
+    def test_weather_db(self):
+        synced_views = []
+
+        @receiver(view_synced)
+        def on_view_synced(sender, **kwargs):
+            synced_views.append(sender)
+
+        call_command("sync_pgviews", database="weather_db")
+        self.assertIn(MonthlyObservation, synced_views)
+        self.assertNotIn(RelatedView, synced_views)
+
+
+@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
+class WeatherPinnedRefreshPGViewsTest(TestCase):
+    """Ensure views are only refreshed on each database using refresh_pgviews"""
+
+    databases = {DEFAULT_DB_ALIAS, "weather_db"}
+
+    def test_default(self):
+        Observation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+        call_command("refresh_pgviews", database=DEFAULT_DB_ALIAS)
+        self.assertEqual(MonthlyObservation.objects.count(), 0)
+
+    def test_weather_db(self):
+        Observation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+        call_command("refresh_pgviews", database="weather_db")
+        self.assertEqual(MonthlyObservation.objects.count(), 1)

--- a/tests/test_project/test_project/settings/base.py
+++ b/tests/test_project/test_project/settings/base.py
@@ -20,7 +20,16 @@ DATABASES = {
         "PASSWORD": "password",
         "HOST": "",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
         "PORT": "",  # Set to empty string for default.
-    }
+    },
+    "weather_db": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        "NAME": "django_pgviews_weatherdb",  # Or path to database file if using sqlite3.
+        # The following settings are not used with sqlite3:
+        "USER": "django_pgviews",
+        "PASSWORD": "password",
+        "HOST": "",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+        "PORT": "",  # Set to empty string for default.
+    },
 }
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
@@ -128,6 +137,7 @@ INSTALLED_APPS = (
     # 'django.contrib.admindocs',
     "django_pgviews",
     "test_project.viewtest",
+    "test_project.multidbtest",
 )
 
 # A sample logging configuration. The only tangible logging

--- a/tests/test_project/test_project/settings/ci.py
+++ b/tests/test_project/test_project/settings/ci.py
@@ -11,5 +11,13 @@ DATABASES = {
         "PASSWORD": os.environ.get("DB_PASSWORD", ":"),
         "HOST": "localhost",
         "PORT": "5432",
-    }
+    },
+    "weather_db": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "NAME": os.environ.get("DB_NAME_WEATHER", "weatherdb"),
+        "USER": os.environ.get("DB_USER", "ubuntu"),
+        "PASSWORD": os.environ.get("DB_PASSWORD", ":"),
+        "HOST": "localhost",
+        "PORT": "5432",
+    },
 }

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ deps=
     dj31: https://github.com/django/django/archive/stable/3.1.x.tar.gz#egg=django
     dj32: https://github.com/django/django/archive/stable/3.1.x.tar.gz#egg=django
 commands=
-    python manage.py test  {posargs:test_project.viewtest}
+    python manage.py test  {posargs:test_project.viewtest test_project.multidbtest}
 passenv = DB_NAME DB_USER DB_PASSWORD


### PR DESCRIPTION
Update `django-pgviews` to support multiple databases (per #9):
- Adds multiple database instructions to README.
- A `--database` option may now be provided to the management commands to specify a non-default database.
- By default, `django-pgviews` continues to use the `default` database and no changes are required for this use case.
- Includes multi-database related unit tests in `tests/test_project/test_project/multidbtest`.
