### PR TITLE
Conditionally use deprecated default_app_config

### DIFF
--- a/django_pgviews/__init__.py
+++ b/django_pgviews/__init__.py
@@ -1,1 +1,2 @@
-default_app_config = "django_pgviews.apps.ViewConfig"
+if django.VERSION < (3, 2):
+  default_app_config = "django_pgviews.apps.ViewConfig"

--- a/django_pgviews/__init__.py
+++ b/django_pgviews/__init__.py
@@ -1,2 +1,4 @@
+import django
+
 if django.VERSION < (3, 2):
   default_app_config = "django_pgviews.apps.ViewConfig"


### PR DESCRIPTION
`default_app_config` is being removed in Django 4.1 and a new warning has shown up since django 3.2

https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-1